### PR TITLE
urls: fix hangup

### DIFF
--- a/src/urls.js
+++ b/src/urls.js
@@ -6,7 +6,7 @@ const base = 'https://app.mango-office.ru/vpbx/';
 const suffix = {
 	call: 'commands/callback',
 	callGroup: 'commands/callback_group',
-	callHangup: 'commands/call/hangup',
+	hangup: 'commands/call/hangup',
 	route: 'commands/route',
 	transfer: 'commands/transfer',
 	users: 'config/users/request',


### PR DESCRIPTION
Привет!

Если вызвать метод vbpx.hangup, то он не дойдёт до API, потому что в файле src/urls.js неправильно названо свойство suffix.hangup. В src/vbpx.js вызывается suffix.hangup, а в файле callHangup.

Из-за этого у нас не сработал сброс звонка и пришлось стучаться в техподдержку, где мне подсказали, что запрос был на `/vpbx/undefined` :−)