### PR TITLE
Transform: fix module.exports

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -140,4 +140,6 @@ class Transform {
     }
 }
 
-module.exports = Transform;
+module.exports = {
+    Transform
+};


### PR DESCRIPTION
В этом конкретном файле класс экспортируется не так, как в других.

Из-за этого в классе VPBX не работает, например, vpbx.dctUserInfo() (функция жалуется на Transform = undefined).

*Пример крашлога:*
```
TypeError: Cannot read property 'dctUserInfo' of undefined
  File "/usr/src/app/node_modules/mango-vpbx/src/vpbx.js", line 315, col 34, in VPBX.dctUserInfo
    transform: Transform.dctUserInfo,
  File "/usr/src/app/dist/callRedirect.js", line 102, col 64, in Realtime.<anonymous>
    dctUserInfoResponse = yield vpbx_1.default.dctUserInfo({
  ?, in Generator.next
  File "/usr/src/app/dist/callRedirect.js", line 4, col 58, in fulfilled
    function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
  ?, in null.<anonymous>
  File "internal/process/next_tick.js", line 228, col 7, in process._tickDomainCallback
```